### PR TITLE
Fix films API to store rating

### DIFF
--- a/films/app.js
+++ b/films/app.js
@@ -18,7 +18,8 @@ app.get('/api/v1/films', (req, res) => {
 
 app.post('/api/v1/films', (req, res) => {
   const name = req.body.name;
-  const film = { name: name };
+  const rating = req.body.rating;
+  const film = { name, rating };
   films.push(film);
   res.json(film);
 });

--- a/public/films.js
+++ b/public/films.js
@@ -32,7 +32,7 @@ const API = (function() {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ name: title })
+                body: JSON.stringify({ name: title, rating })
             });
             await resp.json();
         } catch (e) {
@@ -61,7 +61,7 @@ const API = (function() {
                 row.innerHTML = `
                     <td>${idx + 1}</td>
                     <td>${film.name}</td>
-                    <td><span class="badge">10/10</span></td>
+                    <td><span class="badge">${film.rating}/10</span></td>
                 `;
                 tbody.appendChild(row);
             });


### PR DESCRIPTION
## Summary
- support ratings when adding a film
- send rating from the browser and display it in the table

## Testing
- `node -e "require('./films/app');"` *(fails: Cannot find module 'cors')*

------
https://chatgpt.com/codex/tasks/task_e_686dd52536b083258ae11f1d833bb674