### PR TITLE
Update film table handling

### DIFF
--- a/films/app.js
+++ b/films/app.js
@@ -19,8 +19,15 @@ app.get('/api/v1/films', (req, res) => {
 app.post('/api/v1/films', (req, res) => {
   const name = req.body.name;
   const rating = req.body.rating;
-  const film = { name, rating };
-  films.push(film);
+
+  let film = films.find(f => f.name === name);
+  if (film) {
+    film.rating = rating;
+  } else {
+    film = { name, rating };
+    films.push(film);
+  }
+
   res.json(film);
 });
 

--- a/public/films.js
+++ b/public/films.js
@@ -42,7 +42,10 @@ const API = (function() {
         ratingInput.value = '10';
         showSuccess('Film added successfully!');
 
-        document.getElementById('filmsTable').classList.add('hidden');
+        const table = document.getElementById('filmsTable');
+        if (!table.classList.contains('hidden')) {
+            await getFilms();
+        }
         return false;
     }
 


### PR DESCRIPTION
## Summary
- keep table visible when a film is added
- refresh table after adding if it is visible
- update existing film ratings server-side when duplicates are posted

## Testing
- `npm test` *(fails: Missing script)*
- `npm run start` *(starts server)*

------
https://chatgpt.com/codex/tasks/task_e_686ddadcbfc48325a1b01487131aefb7