### PR TITLE
Fix film table staying visible

### DIFF
--- a/public/films.js
+++ b/public/films.js
@@ -9,7 +9,8 @@ const API = (function() {
         msg.classList.add('hidden');
     }
 
-    async function createFilm() {
+    async function createFilm(event) {
+        if (event) event.preventDefault();
         const input = document.getElementById('filmTitle');
         const ratingInput = document.getElementById('filmRating');
         const title = input.value.trim();
@@ -49,7 +50,8 @@ const API = (function() {
         return false;
     }
 
-    async function getFilms() {
+    async function getFilms(event) {
+        if (event) event.preventDefault();
         const table = document.getElementById('filmsTable');
         const tbody = table.querySelector('tbody');
         tbody.innerHTML = '';

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     <div class="container">
         <h1>Film Ratings Manager</h1>
         
-        <form id="filmForm" onsubmit="return API.createFilm()">
+        <form id="filmForm" onsubmit="API.createFilm(event)">
             <input 
                 type="text" 
                 id="filmTitle" 
@@ -33,7 +33,7 @@
         </form>
         <div id="successMessage" class="hidden"></div>
         
-        <form id="getFilmsForm" onsubmit="return API.getFilms()">
+        <form id="getFilmsForm" onsubmit="API.getFilms(event)">
             <button type="submit">Get Films</button>
         </form>
         


### PR DESCRIPTION
## Summary
- stop form submissions from reloading the page
- send `event` object to the script handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ddd353b808325bfd00f69b57d67c0